### PR TITLE
Potential fix for code scanning alert no. 12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Arsabutispik/Khaxy/security/code-scanning/12](https://github.com/Arsabutispik/Khaxy/security/code-scanning/12)

To fix the issue, we will add a `permissions` block to the root of the workflow file. This block will explicitly define the least privileges required for the workflow. Since the workflow does not interact with repository contents or require write access, we will set `contents: read` as the minimal permission. This ensures the `GITHUB_TOKEN` has restricted access while maintaining functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
