### PR TITLE
Potential fix for code scanning alert no. 13: Server-side request forgery

### DIFF
--- a/apps/web/src/actions/updateGuildConfig.ts
+++ b/apps/web/src/actions/updateGuildConfig.ts
@@ -6,6 +6,10 @@ export async function updateConfig(
   guildId: string,
   data: Partial<Guilds>,
 ): Promise<Guilds> {
+  // Only allow guild IDs matching 17-19 digits (Discord snowflake format)
+  if (!/^\d{17,19}$/.test(guildId)) {
+    throw new Error("Invalid guildId format");
+  }
   const API_BASE_URL = process.env.FASTIFY_API_URL;
   const API_KEY = process.env.INTERNAL_API_KEY;
   const res = await fetch(`${API_BASE_URL}/api/guilds/${guildId}/settings`, {


### PR DESCRIPTION
Potential fix for [https://github.com/Arsabutispik/Khaxy/security/code-scanning/13](https://github.com/Arsabutispik/Khaxy/security/code-scanning/13)

The best way to fix this SSRF vulnerability is to restrict `guildId` to a known-safe set or format, or at the very least validate it to ensure the value is strictly an allowed `guildId` (e.g., a UUID, a numeric ID, or an allowable slug). This prevents path traversal, special characters, or untrusted resource requests.

**How to fix:**  
- Validate `guildId` before interpolating it into the URL.
- Reject or sanitize values that don't fit a safe pattern (e.g., with a regex).
- Optionally, use allow-lists if possible (not likely here, since IDs are not usually all enumerated).
- Only interpolate trusted, validated data in the path.

**What to change:**  
- Add input validation for `guildId` at the start of this function.
- Throw an error or otherwise prevent further processing if validation fails.
- Add a suitable regular expression pattern for `guildId`. For many Discord-like systems, these are 17-19 digit snowflake IDs: `/^\d{17,19}$/`. If it's a UUID, use `/^[0-9a-fA-F-]{36}$/`.
- No new dependencies are necessary.
- No changes to existing functionality beyond validation.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
